### PR TITLE
Husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint:fix && yarn tsc && yarn lint

--- a/package.json
+++ b/package.json
@@ -48,10 +48,5 @@
   "devDependencies": {
     "eslint": "^8.17.0",
     "husky": "^8.0.1"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "yarn lint:fix && yarn tsc && yarn lint"
-    }
   }
 }


### PR DESCRIPTION
Permet d'ajouter de formater & fix les petits erreurs eslint avant le commit 

Si toutefois il y a des erreurs que prettier ne peut corriger alors le commit ne passe pas.